### PR TITLE
Send Bad Request if request params are not as required

### DIFF
--- a/app/controllers/v_cards_controller.rb
+++ b/app/controllers/v_cards_controller.rb
@@ -1,7 +1,6 @@
 class VCardsController < ApplicationController
   def show
-    return unless params[:id]
-    @office = OfficeLocation.find_with_rep(params[:id]).first
+    @office = OfficeLocation.find_with_rep(params.require(:id)).first
     @rep    = @office.rep
 
     send_data @office.v_card, filename: "#{@rep.official_full} #{@rep.state.abbr}.vcf"


### PR DESCRIPTION
Use `params.require(:id)` to respond with Bad Request should id parameter not be included in request.