### PR TITLE
add link to prebuilt Vagrant BOX

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 WIP.
 The companion to [the Phone Your Rep frontend](https://github.com/Flaque/phone-your-rep/tree/gh-pages).
 
+# Vagrant
+If you are too busy to do the manual installation, you can download a Vagrant BOX which has the requirements below already installed, download it here.
+
+https://s3.amazonaws.com/debugpyr/pyr.box
+
 # Installation
 
 Be sure to use Ruby 2.3.3.


### PR DESCRIPTION
I've uploaded the pre-built Vagrant box to AWS S3, added link to readme